### PR TITLE
Speed up test

### DIFF
--- a/assets/samplesheets/test_input_channels.yml
+++ b/assets/samplesheets/test_input_channels.yml
@@ -5,7 +5,7 @@ samples:
       ploidy: 2
       busco_lineages:
         - "eukaryota_odb10"
-        - "mammalia_odb10"
+        - "bacteria_odb10"
     assembly:
       - id: HSapiensA_diploid
         pri_asm: "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.fasta"

--- a/conf/test.config
+++ b/conf/test.config
@@ -26,4 +26,6 @@ params {
     outdir     = 'results'
     tracedir   = "${params.outdir}/pipeline_info"
     publish_dir_mode = 'symlink'
+
+    busco_lineage = "bacteria_odb10"
 }


### PR DESCRIPTION
I run the test profile and it took ages. BUSCO required 4.2GB disk space for each run in the work dir and it did 4 runs. 3.7GB were in folder busco_downloads. That seems excessive. I suggest to not run busco with busco_lineages="auto" for tests but specify a lineage with only few BUSCOs, that should speed up the process. Also see nf-core/mag for its [test profile](https://github.com/nf-core/mag/blob/a8e92af70eca59a92b72262e6cdde11e69375801/conf/test.config#L29).

This PR is supposed to check out whether that change indeed benefits testing stability and speed here.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/genomeassembler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/genomeassembler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
