### PR TITLE
README: switch metromap based on theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ Currently, this pipeline does not implement phasing of polyploid genomes or HiC 
   <img alt="nf-core/genomeassembler" src="docs/images/genomeassembler.light.png">
 </picture>
 
-![Pipeline metromap](docs/images/genomeassembler.light.png)
-
 ## Usage
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@
 **nf-core/genomeassembler** is a bioinformatics pipeline that carries out genome assembly, polishing and scaffolding from long reads (ONT or pacbio). Assembly can be done via `flye` or `hifiasm`, polishing can be carried out with `medaka` (ONT), or `pilon` (requires short-reads), and scaffolding can be done using `LINKS`, `Longstitch`, or `RagTag` (if a reference is available). Quality control includes `BUSCO`, `QUAST` and `merqury` (requires short-reads).
 Currently, this pipeline does not implement phasing of polyploid genomes or HiC scaffolding.
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/images/genomeassembler.dark.png">
+  <img alt="nf-core/genomeassembler" src="docs/images/genomeassembler.light.png">
+</picture>
+
 ![Pipeline metromap](docs/images/genomeassembler.light.png)
 
 ## Usage


### PR DESCRIPTION
The metromap displayed in the readme now switches between light/dark version based on GH color scheme.