### PR TITLE
use different container for collect_reads

### DIFF
--- a/modules/local/collect_reads/environment.yml
+++ b/modules/local/collect_reads/environment.yml
@@ -1,0 +1,10 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::coreutils=9.5
+  - conda-forge::grep=3.11
+  - conda-forge::gzip=1.13
+  - conda-forge::lbzip2=2.5
+  - conda-forge::sed=4.8
+  - conda-forge::tar=1.34

--- a/modules/local/collect_reads/main.nf
+++ b/modules/local/collect_reads/main.nf
@@ -2,10 +2,10 @@ process COLLECT_READS {
     tag "$meta.id"
     label 'process_low'
 
-    conda "conda-forge::python=3.11"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/python:3.11':
-        'biocontainers/python:3.11' }"
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/52ccce28d2ab928ab862e25aae26314d69c8e38bd41ca9431c67ef05221348aa/data'
+        : 'community.wave.seqera.io/library/coreutils_grep_gzip_lbzip2_pruned:838ba80435a629f8'}"
     input:
     tuple val(meta), path(read_directory)
 


### PR DESCRIPTION
The `collect_reads` module was using a python3.11 container, but it seems more reasonable to use the coreutils / grep / gzip container and environment that is also used by `gfa2fa`.