### PR TITLE
indentation in report yaml

### DIFF
--- a/assets/report/report.qmd
+++ b/assets/report/report.qmd
@@ -4,8 +4,8 @@ author: "Niklas Schandry"
 format: dashboard
 editor: source
 nav-buttons:
-        - icon: github
-            href: https://github.com/nschan/genomeassembler
+    - icon: github
+    - href: https://github.com/nf-core/genomeassembler
 params:
     nanoq: false
     busco: false


### PR DESCRIPTION
There was extra indentation in the yaml header of the report qmd file, which caused an error during rendering. I assume I added this by accident when I changed indentation to please `.editorconfig`. I have also updated the link to link to the nf-core repo instead of my fork.