### PR TITLE
Longstitch outputs; report header

### DIFF
--- a/assets/report/report.qmd
+++ b/assets/report/report.qmd
@@ -4,8 +4,8 @@ author: "Niklas Schandry"
 format: dashboard
 editor: source
 nav-buttons:
-        - icon: github
-            href: https://github.com/nschan/genomeassembler
+    - icon: github
+    - href: https://github.com/nf-core/genomeassembler
 params:
     nanoq: false
     busco: false

--- a/modules/local/longstitch/main.nf
+++ b/modules/local/longstitch/main.nf
@@ -35,8 +35,13 @@ process LONGSTITCH {
     fi
 
     longstitch tigmint-ntLink-arks draft=assembly reads=reads t=${task.cpus} G=135e6 out_prefix=${prefix}
-    cat *.tigmint-ntLink-arks.longstitch-scaffolds.fa | sed 's/\\(scaffold[0-9]*\\),.*/\\1/' > ${prefix}.tigmint-ntLink-arks.longstitch-scaffolds.fa
-    cat *.tigmint-ntLink.longstitch-scaffolds.fa | sed 's/\\(scaffold[0-9]*\\),.*/\\1/' > ${prefix}.tigmint-ntLink.longstitch-scaffolds.fa
+
+    mv *.tigmint-ntLink-arks.longstitch-scaffolds.fa ${prefix}.tigmint-ntLink-arks.longstitch-scaffolds.fa
+    sed -i 's/\\(scaffold[0-9]*\\),.*/\\1/' ${prefix}.tigmint-ntLink-arks.longstitch-scaffolds.fa
+
+
+    mv  *.tigmint-ntLink.longstitch-scaffolds.fa  ${prefix}.tigmint-ntLink.longstitch-scaffolds.fa
+    sed -i 's/\\(scaffold[0-9]*\\),.*/\\1/' ${prefix}.tigmint-ntLink.longstitch-scaffolds.fa
     """
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"


### PR DESCRIPTION
The longstitch module sometimes (?) emitted two files in the output channels, since the original file was not removed after the one named based on `prefix` was created.

The report.qmd header contained extra indentation (cp #85 which I will close after merging this one).