### PR TITLE
quast output path

### DIFF
--- a/modules/local/quast/main.nf
+++ b/modules/local/quast/main.nf
@@ -13,7 +13,7 @@ process QUAST {
     val use_gff
 
     output:
-    path "${prefix}/*", emit: results
+    path "${meta.id}*/", emit: results
     path "*report.tsv", emit: tsv
     path "versions.yml", emit: versions
 

--- a/modules/local/quast/main.nf
+++ b/modules/local/quast/main.nf
@@ -13,7 +13,7 @@ process QUAST {
     val use_gff
 
     output:
-    path "${prefix}*", emit: results
+    path "${prefix}/*", emit: results
     path "*report.tsv", emit: tsv
     path "versions.yml", emit: versions
 

--- a/modules/local/quast/main.nf
+++ b/modules/local/quast/main.nf
@@ -13,7 +13,7 @@ process QUAST {
     val use_gff
 
     output:
-    path "${meta.id}*/", emit: results
+    path "${meta.id}*/*", emit: results
     path "*report.tsv", emit: tsv
     path "versions.yml", emit: versions
 


### PR DESCRIPTION
When updating quast, I forgot a `/` in the `results` output path.