### PR TITLE
Fix modules.conf: ragtag map assembly output path

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -355,7 +355,7 @@ process {
     withName: '.*RAGTAG:.*MAP_TO_ASSEMBLY.*' {
         ext.prefix = { "${meta.id}_ragtag" }
         publishDir = [
-            path: { "${params.outdir}/QC/scaffold/ragtag/quast/${meta.id}/map_to_ref/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            path: { "${params.outdir}/QC/scaffold/ragtag/quast/${meta.id}/map_to_assembly/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/modules/local/quast/main.nf
+++ b/modules/local/quast/main.nf
@@ -13,7 +13,7 @@ process QUAST {
     val use_gff
 
     output:
-    path "${prefix}/*", emit: results
+    path "${meta.id}*/", emit: results
     path "*report.tsv", emit: tsv
     path "versions.yml", emit: versions
 

--- a/modules/local/quast/main.nf
+++ b/modules/local/quast/main.nf
@@ -13,7 +13,7 @@ process QUAST {
     val use_gff
 
     output:
-    path "${prefix}*", emit: results
+    path "${prefix}/*", emit: results
     path "*report.tsv", emit: tsv
     path "versions.yml", emit: versions
 

--- a/modules/local/quast/main.nf
+++ b/modules/local/quast/main.nf
@@ -13,7 +13,7 @@ process QUAST {
     val use_gff
 
     output:
-    path "${meta.id}*/", emit: results
+    path "${meta.id}*/*", emit: results
     path "*report.tsv", emit: tsv
     path "versions.yml", emit: versions
 


### PR DESCRIPTION
There was a mistake in the output path for the map_to_assembly output for the ragtag module.
Other commits for quast belong into #87 