### PR TITLE
update LIFTOFF patterns

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -491,7 +491,7 @@ process {
     now nf-core module
     --------
     */
-    withName: '.*:ASSEMBLE:.*LIFTOFF' {
+    withName: '.*ASSEMBLE:.*LIFTOFF' {
         publishDir = [
             path: { "${params.outdir}/liftoff/${meta.id}/assemble/" },
             mode: params.publish_dir_mode,
@@ -500,7 +500,7 @@ process {
         ext.prefix = { "${meta.id}_assembly" }
     }
 
-    withName: '.*:PILON:.*LIFTOFF' {
+    withName: '.*PILON:.*LIFTOFF' {
         publishDir = [
             path: { "${params.outdir}/liftoff/${meta.id}/polish/pilon" },
             mode: params.publish_dir_mode,
@@ -508,7 +508,7 @@ process {
         ]
         ext.prefix = { "${meta.id}_pilon" }
     }
-    withName: '.*:MEDAKA:.*LIFTOFF' {
+    withName: '.*MEDAKA:.*LIFTOFF' {
         publishDir = [
             path: { "${params.outdir}liftoff/${meta.id}/polish/medaka" },
             mode: params.publish_dir_mode,
@@ -516,7 +516,7 @@ process {
         ]
         ext.prefix = { "${meta.id}_medaka" }
     }
-    withName: '.*:RAGTAG:.*LIFTOFF' {
+    withName: '.*RAGTAG:.*LIFTOFF' {
         publishDir = [
             path: { "${params.outdir}/liftoff/${meta.id}/scaffold/ragtag/" },
             mode: params.publish_dir_mode,
@@ -524,7 +524,7 @@ process {
         ]
         ext.prefix = { "${meta.id}_ragtag" }
     }
-    withName: '.*:LONGSTITCH:.*LIFTOFF' {
+    withName: '.*LONGSTITCH:.*LIFTOFF' {
         publishDir = [
             path: { "${params.outdir}liftoff/${meta.id}/scaffold/longstitch" },
             mode: params.publish_dir_mode,
@@ -532,7 +532,7 @@ process {
         ]
         ext.prefix = { "${meta.id}_longstitch" }
     }
-    withName: '.*:LINKS:.*LIFTOFF' {
+    withName: '.*LINKS:.*LIFTOFF' {
         publishDir = [
             path: { "${params.outdir}liftoff/${meta.id}/scaffold/links" },
             mode: params.publish_dir_mode,


### PR DESCRIPTION
I noticed a mistake in the patterns for liftoff; since it is included in the `RUN_TOOL` subworkflows, the pattern must not include the `:` before `TOOL` 