### PR TITLE
remove ch_assembly_bam_bai, less outputs from map_to_assembly, indentation in jellyfish workflow

### DIFF
--- a/subworkflows/local/assemble/main.nf
+++ b/subworkflows/local/assemble/main.nf
@@ -132,10 +132,6 @@ workflow ASSEMBLE {
         ch_input
             .map { row -> [row.meta, row.assembly_bam] }
             .set { ch_assembly_bam }
-
-        ch_input
-            .map { row -> [row.meta, row.assembly_bam, row.assembly_bai] }
-            .set { ch_assembly_bam_bai }
     }
     else {
         Channel.empty().set { ch_ref_bam }
@@ -173,7 +169,6 @@ workflow ASSEMBLE {
             MAP_TO_ASSEMBLY(longreads, ch_assembly)
             MAP_TO_ASSEMBLY.out.aln_to_assembly_bam.set { ch_assembly_bam }
 
-            MAP_TO_ASSEMBLY.out.aln_to_assembly_bam_bai.set { ch_assembly_bam_bai }
             RUN_QUAST(ch_assembly, ch_input, ch_ref_bam, ch_assembly_bam)
             RUN_QUAST.out.quast_tsv.set { assembly_quast_reports }
         }

--- a/subworkflows/local/jellyfish/main.nf
+++ b/subworkflows/local/jellyfish/main.nf
@@ -15,17 +15,17 @@ workflow JELLYFISH {
     COUNT.out.set { kmers }
 
     if (params.dump) {
-    DUMP(kmers)
+        DUMP(kmers)
     }
 
     HISTO(kmers)
 
     if (!params.read_length == null) {
-    HISTO.out.map { it -> [it[0], it[1], params.kmer_length, params.read_length] }.set { genomescope_in }
+        HISTO.out.map { it -> [it[0], it[1], params.kmer_length, params.read_length] }.set { genomescope_in }
     }
 
     if (params.read_length == null) {
-    HISTO.out.map { it -> [it[0], it[1], params.kmer_length] }.join(nanoq_out).set { genomescope_in }
+        HISTO.out.map { it -> [it[0], it[1], params.kmer_length] }.join(nanoq_out).set { genomescope_in }
     }
 
     GENOMESCOPE(genomescope_in)

--- a/subworkflows/local/mapping/map_to_assembly/main.nf
+++ b/subworkflows/local/mapping/map_to_assembly/main.nf
@@ -29,6 +29,4 @@ workflow MAP_TO_ASSEMBLY {
 
     emit:
     aln_to_assembly_bam
-    aln_to_assembly_bai
-    aln_to_assembly_bam_bai
 }

--- a/subworkflows/local/mapping/map_to_assembly/main.nf
+++ b/subworkflows/local/mapping/map_to_assembly/main.nf
@@ -32,4 +32,5 @@ workflow MAP_TO_ASSEMBLY {
 
     emit:
     aln_to_assembly_bam
+    versions
 }


### PR DESCRIPTION
This removes unused outputs (`*_bam_bai`) from `MAP_TO_ASSEMBLY` and updates `ASSEMBLE` to remove the channel that contained those outputs and did nothing with them.

I also added indentation in two if blocks in the jellyfish workflow.