### PR TITLE
Fix output names

### DIFF
--- a/subworkflows/local/assemble/main.nf
+++ b/subworkflows/local/assemble/main.nf
@@ -174,7 +174,7 @@ workflow ASSEMBLE {
             if (params.use_ref) {
                 MAP_TO_REF(longreads, ch_refs)
 
-                MAP_TO_REF.out.ch_aln_to_ref.set { ch_ref_bam }
+                MAP_TO_REF.out.ch_aln_to_ref_bam.set { ch_ref_bam }
             }
 
             MAP_TO_ASSEMBLY(longreads, ch_assembly)

--- a/subworkflows/local/jellyfish/main.nf
+++ b/subworkflows/local/jellyfish/main.nf
@@ -26,11 +26,11 @@ workflow JELLYFISH {
     ch_versions = ch_versions.mix(HISTO.out.versions)
 
     if (!params.read_length == null) {
-        HISTO.out.map { it -> [it[0], it[1], params.kmer_length, params.read_length] }.set { genomescope_in }
+        HISTO.out.histo.map { it -> [it[0], it[1], params.kmer_length, params.read_length] }.set { genomescope_in }
     }
 
     if (params.read_length == null) {
-        HISTO.out.map { it -> [it[0], it[1], params.kmer_length] }.join(nanoq_out).set { genomescope_in }
+        HISTO.out.histo.map { it -> [it[0], it[1], params.kmer_length] }.join(nanoq_out).set { genomescope_in }
     }
 
     GENOMESCOPE(genomescope_in)


### PR DESCRIPTION
During some final tests I noticed that there were bugs introduced:

- I added version outputs for jellyfish and did not update the `.out` in the workflow.
- I renamed the output from the map_to_ref workflow and did not update the `.out` in the assembly workflow.
