### PR TITLE
optional merqury outputs for awstest

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -39,7 +39,8 @@
                     "merqury/merqury": {
                         "branch": "master",
                         "git_sha": "42140b76b12c18dbde34bfa7f2ef09afae8b054f",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/merqury/merqury/merqury-merqury.diff"
                     },
                     "meryl/count": {
                         "branch": "master",

--- a/modules/nf-core/merqury/merqury/main.nf
+++ b/modules/nf-core/merqury/merqury/main.nf
@@ -12,8 +12,8 @@ process MERQURY_MERQURY {
     tuple val(meta), path(meryl_db), path(assembly)
 
     output:
-    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed
-    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig
+    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed, optional: true
+    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig, optional: true
     tuple val(meta), path("*.completeness.stats"), emit: stats
     tuple val(meta), path("*.dist_only.hist")    , emit: dist_hist
     tuple val(meta), path("*.spectra-cn.fl.png") , emit: spectra_cn_fl_png

--- a/modules/nf-core/merqury/merqury/main.nf
+++ b/modules/nf-core/merqury/merqury/main.nf
@@ -12,8 +12,8 @@ process MERQURY_MERQURY {
     tuple val(meta), path(meryl_db), path(assembly)
 
     output:
-    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed, optional: true
-    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig, optional: true
+    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed, optional: true // optional to make full_test pass, where this file is not created.
+    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig, optional: true // optional to make full_test pass, where this file is not created.
     tuple val(meta), path("*.completeness.stats"), emit: stats
     tuple val(meta), path("*.dist_only.hist")    , emit: dist_hist
     tuple val(meta), path("*.spectra-cn.fl.png") , emit: spectra_cn_fl_png

--- a/modules/nf-core/merqury/merqury/merqury-merqury.diff
+++ b/modules/nf-core/merqury/merqury/merqury-merqury.diff
@@ -1,0 +1,22 @@
+Changes in component 'nf-core/merqury/merqury'
+'modules/nf-core/merqury/merqury/environment.yml' is unchanged
+'modules/nf-core/merqury/merqury/meta.yml' is unchanged
+Changes in 'merqury/merqury/main.nf':
+--- modules/nf-core/merqury/merqury/main.nf
++++ modules/nf-core/merqury/merqury/main.nf
+@@ -12,8 +12,8 @@
+     tuple val(meta), path(meryl_db), path(assembly)
+ 
+     output:
+-    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed
+-    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig
++    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed, optional: true
++    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig, optional: true
+     tuple val(meta), path("*.completeness.stats"), emit: stats
+     tuple val(meta), path("*.dist_only.hist")    , emit: dist_hist
+     tuple val(meta), path("*.spectra-cn.fl.png") , emit: spectra_cn_fl_png
+
+'modules/nf-core/merqury/merqury/tests/tags.yml' is unchanged
+'modules/nf-core/merqury/merqury/tests/main.nf.test' is unchanged
+'modules/nf-core/merqury/merqury/tests/main.nf.test.snap' is unchanged
+************************************************************

--- a/modules/nf-core/merqury/merqury/merqury-merqury.diff
+++ b/modules/nf-core/merqury/merqury/merqury-merqury.diff
@@ -10,8 +10,8 @@ Changes in 'merqury/merqury/main.nf':
      output:
 -    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed
 -    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig
-+    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed, optional: true
-+    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig, optional: true
++    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed, optional: true // optional to make full_test pass, where this file is not created.
++    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig, optional: true // optional to make full_test pass, where this file is not created.
      tuple val(meta), path("*.completeness.stats"), emit: stats
      tuple val(meta), path("*.dist_only.hist")    , emit: dist_hist
      tuple val(meta), path("*.spectra-cn.fl.png") , emit: spectra_cn_fl_png


### PR DESCRIPTION
The AWS test fails because merqury does not create the `_only.bed` file. 
I think this might be because of how the test-dataset was generated: it only contains reads that map to the region that is assembled, and I guess this could mean that there are no exclusive kmers?