### PR TITLE
replace meta_id with meta.id in ASSEMBLE:RAGTAG_SCAFFOLD

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -184,7 +184,7 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        ext.prefix = { "${meta_id}_assembly_scaffold"}
+        ext.prefix = { "${meta.id}_assembly_scaffold" }
     }
 
     /*


### PR DESCRIPTION
While exploring why test AWS tests fail, I noticed a weird filename, which i tracked back to using `meta_id` instead of `meta.id` in the closure that provides the `prefix` for this process.