### PR TITLE
patch merqury for AWS test

### DIFF
--- a/modules/nf-core/merqury/merqury/main.nf
+++ b/modules/nf-core/merqury/merqury/main.nf
@@ -12,22 +12,22 @@ process MERQURY_MERQURY {
     tuple val(meta), path(meryl_db), path(assembly)
 
     output:
-    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed, optional: true // optional to make full_test pass, where this file is not created.
-    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig, optional: true // optional to make full_test pass, where this file is not created.
+    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed
+    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig
     tuple val(meta), path("*.completeness.stats"), emit: stats
     tuple val(meta), path("*.dist_only.hist")    , emit: dist_hist
     tuple val(meta), path("*.spectra-cn.fl.png") , emit: spectra_cn_fl_png
     tuple val(meta), path("*.spectra-cn.hist")   , emit: spectra_cn_hist
     tuple val(meta), path("*.spectra-cn.ln.png") , emit: spectra_cn_ln_png
     tuple val(meta), path("*.spectra-cn.st.png") , emit: spectra_cn_st_png
-    tuple val(meta), path("*.spectra-asm.fl.png"), emit: spectra_asm_fl_png
-    tuple val(meta), path("*.spectra-asm.hist")  , emit: spectra_asm_hist
-    tuple val(meta), path("*.spectra-asm.ln.png"), emit: spectra_asm_ln_png
-    tuple val(meta), path("*.spectra-asm.st.png"), emit: spectra_asm_st_png
+    tuple val(meta), path("*.spectra-asm.fl.png"), emit: spectra_asm_fl_png,    optional: true // optional to make full_test pass, where this file is not created.
+    tuple val(meta), path("*.spectra-asm.hist")  , emit: spectra_asm_hist,      optional: true // optional to make full_test pass, where this file is not created.
+    tuple val(meta), path("*.spectra-asm.ln.png"), emit: spectra_asm_ln_png,    optional: true // optional to make full_test pass, where this file is not created.
+    tuple val(meta), path("*.spectra-asm.st.png"), emit: spectra_asm_st_png,    optional: true // optional to make full_test pass, where this file is not created.
     tuple val(meta), path("${prefix}.qv")        , emit: assembly_qv
-    tuple val(meta), path("${prefix}.*.qv")      , emit: scaffold_qv
-    tuple val(meta), path("*.hist.ploidy")       , emit: read_ploidy
-    tuple val(meta), path("*.hapmers.blob.png")  , emit: hapmers_blob_png           , optional: true
+    tuple val(meta), path("${prefix}.*.qv")      , emit: scaffold_qv,           optional: true // optional to make full_test pass, where this file is not created.
+    tuple val(meta), path("*.hist.ploidy")       , emit: read_ploidy,           optional: true // optional to make full_test pass, where this file is not created.
+    tuple val(meta), path("*.hapmers.blob.png")  , emit: hapmers_blob_png,      optional: true
     path "versions.yml"                          , emit: versions
 
     when:

--- a/modules/nf-core/merqury/merqury/merqury-merqury.diff
+++ b/modules/nf-core/merqury/merqury/merqury-merqury.diff
@@ -4,17 +4,28 @@ Changes in component 'nf-core/merqury/merqury'
 Changes in 'merqury/merqury/main.nf':
 --- modules/nf-core/merqury/merqury/main.nf
 +++ modules/nf-core/merqury/merqury/main.nf
-@@ -12,8 +12,8 @@
-     tuple val(meta), path(meryl_db), path(assembly)
+@@ -20,14 +20,14 @@
+     tuple val(meta), path("*.spectra-cn.hist")   , emit: spectra_cn_hist
+     tuple val(meta), path("*.spectra-cn.ln.png") , emit: spectra_cn_ln_png
+     tuple val(meta), path("*.spectra-cn.st.png") , emit: spectra_cn_st_png
+-    tuple val(meta), path("*.spectra-asm.fl.png"), emit: spectra_asm_fl_png
+-    tuple val(meta), path("*.spectra-asm.hist")  , emit: spectra_asm_hist
+-    tuple val(meta), path("*.spectra-asm.ln.png"), emit: spectra_asm_ln_png
+-    tuple val(meta), path("*.spectra-asm.st.png"), emit: spectra_asm_st_png
++    tuple val(meta), path("*.spectra-asm.fl.png"), emit: spectra_asm_fl_png,    optional: true // optional to make full_test pass, where this file is not created.
++    tuple val(meta), path("*.spectra-asm.hist")  , emit: spectra_asm_hist,      optional: true // optional to make full_test pass, where this file is not created.
++    tuple val(meta), path("*.spectra-asm.ln.png"), emit: spectra_asm_ln_png,    optional: true // optional to make full_test pass, where this file is not created.
++    tuple val(meta), path("*.spectra-asm.st.png"), emit: spectra_asm_st_png,    optional: true // optional to make full_test pass, where this file is not created.
+     tuple val(meta), path("${prefix}.qv")        , emit: assembly_qv
+-    tuple val(meta), path("${prefix}.*.qv")      , emit: scaffold_qv
+-    tuple val(meta), path("*.hist.ploidy")       , emit: read_ploidy
+-    tuple val(meta), path("*.hapmers.blob.png")  , emit: hapmers_blob_png           , optional: true
++    tuple val(meta), path("${prefix}.*.qv")      , emit: scaffold_qv,           optional: true // optional to make full_test pass, where this file is not created.
++    tuple val(meta), path("*.hist.ploidy")       , emit: read_ploidy,           optional: true // optional to make full_test pass, where this file is not created.
++    tuple val(meta), path("*.hapmers.blob.png")  , emit: hapmers_blob_png,      optional: true
+     path "versions.yml"                          , emit: versions
  
-     output:
--    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed
--    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig
-+    tuple val(meta), path("*_only.bed")          , emit: assembly_only_kmers_bed, optional: true // optional to make full_test pass, where this file is not created.
-+    tuple val(meta), path("*_only.wig")          , emit: assembly_only_kmers_wig, optional: true // optional to make full_test pass, where this file is not created.
-     tuple val(meta), path("*.completeness.stats"), emit: stats
-     tuple val(meta), path("*.dist_only.hist")    , emit: dist_hist
-     tuple val(meta), path("*.spectra-cn.fl.png") , emit: spectra_cn_fl_png
+     when:
 
 'modules/nf-core/merqury/merqury/tests/tags.yml' is unchanged
 'modules/nf-core/merqury/merqury/tests/main.nf.test' is unchanged


### PR DESCRIPTION
This is another attempt at getting merqury to work with the test dataset.
We have updated the short-read test data in https://github.com/nschan/test-datasets/tree/genomeassembler to have more differences between shortread and assembled sequences. Still, this dataset remains artificial and only produces a single contig/sequence during assembly, which means that some of the merqury files are not created.