### PR TITLE
AWS-test: busco output dirs

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -11,53 +11,35 @@
 */
 
 process {
-withName: '.*:ASSEMBLE:.*:BUSCO' {
-        ext.prefix = { "${meta.id}_assembly-${lineage}" }
+    withName: '.*:ASSEMBLE:.*:BUSCO' {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/assemble" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
     withName: '.*PILON:.*:BUSCO' {
-        ext.prefix = { "${meta.id}_pilon-${lineage}" }
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/pilon" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
     withName: '.*MEDAKA:.*:BUSCO' {
-        ext.prefix = { "${meta.id}_medaka-${lineage}" }
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/medaka" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
     withName: '.*LINKS:.*:BUSCO' {
-        ext.prefix = { "${meta.id}_links-${lineage}" }
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/links" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
     withName: '.*LONGSTITCH:.*:BUSCO' {
-        ext.prefix = { "${meta.id}_longstitch-${lineage}" }
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/longstitch" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
     // avoid catching ragtag from ont_on_hifi assembly
     withName: '.*:SCAFFOLD:.*RAGTAG:.*:BUSCO' {
-        ext.prefix = { "${meta.id}_ragtag-${lineage}" }
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/ragtag" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -10,6 +10,59 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+withName: '.*:ASSEMBLE:.*:BUSCO' {
+        ext.prefix = { "${meta.id}_assembly-${lineage}" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/BUSCO/assemble" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+    withName: '.*PILON:.*:BUSCO' {
+        ext.prefix = { "${meta.id}_pilon-${lineage}" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/BUSCO/pilon" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+    withName: '.*MEDAKA:.*:BUSCO' {
+        ext.prefix = { "${meta.id}_medaka-${lineage}" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/BUSCO/medaka" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+    withName: '.*LINKS:.*:BUSCO' {
+        ext.prefix = { "${meta.id}_links-${lineage}" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/BUSCO/links" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+    withName: '.*LONGSTITCH:.*:BUSCO' {
+        ext.prefix = { "${meta.id}_longstitch-${lineage}" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/BUSCO/longstitch" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+    // avoid catching ragtag from ont_on_hifi assembly
+    withName: '.*:SCAFFOLD:.*RAGTAG:.*:BUSCO' {
+        ext.prefix = { "${meta.id}_ragtag-${lineage}" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/BUSCO/ragtag" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+}
+
 params {
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'


### PR DESCRIPTION
This is an attempt to fix the failing AWS megatest. It fails because BUSCO emits the lineage-dir into `QC/BUSCO` and it seems that this causes problems with overwriting in the outdir when there are subfolders emitted that are not empty (at least that is my understanding of the error message). For this test only, the busco steps now emit into a subworkflow specific subdir (`QC/BUSCO/<stage>`). This error is specific for runs where the lineage files are downloaded by the pipeline, and probably S3. I think users should pre-fetch the busco lineage for production runs, otherwise each BUSCO process will download the lineage files again.