### PR TITLE
Disable publishing of BUSCO downloads

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -319,6 +319,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/" },
             mode: params.publish_dir_mode,
+            pattern: "*{-busco,_summary}*",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -327,6 +328,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/" },
             mode: params.publish_dir_mode,
+            pattern: "*{-busco,_summary}*",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -335,6 +337,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/" },
             mode: params.publish_dir_mode,
+            pattern: "*{-busco,_summary}*",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -343,6 +346,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/" },
             mode: params.publish_dir_mode,
+            pattern: "*{-busco,_summary}*",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -351,6 +355,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/" },
             mode: params.publish_dir_mode,
+            pattern: "*{-busco,_summary}*",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -360,6 +365,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/QC/BUSCO/" },
             mode: params.publish_dir_mode,
+            pattern: "*{-busco,_summary}*",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -10,41 +10,6 @@
 ----------------------------------------------------------------------------------------
 */
 
-process {
-    withName: '.*:ASSEMBLE:.*:BUSCO' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/QC/BUSCO/assemble" },
-        ]
-    }
-    withName: '.*PILON:.*:BUSCO' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/QC/BUSCO/pilon" },
-        ]
-    }
-    withName: '.*MEDAKA:.*:BUSCO' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/QC/BUSCO/medaka" },
-        ]
-    }
-    withName: '.*LINKS:.*:BUSCO' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/QC/BUSCO/links" },
-        ]
-    }
-    withName: '.*LONGSTITCH:.*:BUSCO' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/QC/BUSCO/longstitch" },
-        ]
-    }
-    // avoid catching ragtag from ont_on_hifi assembly
-    withName: '.*:SCAFFOLD:.*RAGTAG:.*:BUSCO' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/QC/BUSCO/ragtag" },
-        ]
-    }
-
-}
-
 params {
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'


### PR DESCRIPTION
Publishing `busco_downloads/` creates a problem during AWS tests. 

The glob `*{-busco,_summary}*` specified in the `publishDir` `pattern` should catch all other files created by BUSCO:

```
    tuple val(meta), path("*-busco.batch_summary.txt")                , emit: batch_summary
    tuple val(meta), path("short_summary.*.txt")                      , emit: short_summaries_txt   , optional: true
    tuple val(meta), path("short_summary.*.json")                     , emit: short_summaries_json  , optional: true
    tuple val(meta), path("*-busco/*/run_*/full_table.tsv")           , emit: full_table            , optional: true
    tuple val(meta), path("*-busco/*/run_*/missing_busco_list.tsv")   , emit: missing_busco_list    , optional: true
    tuple val(meta), path("*-busco/*/run_*/single_copy_proteins.faa") , emit: single_copy_proteins  , optional: true
    tuple val(meta), path("*-busco/*/run_*/busco_sequences")          , emit: seq_dir               , optional: true
    tuple val(meta), path("*-busco/*/translated_proteins")            , emit: translated_dir        , optional: true
    tuple val(meta), path("*-busco")                                  , emit: busco_dir
    tuple val(meta), path("busco_downloads/lineages/*")               , emit: downloaded_lineages   , optional: true
```