### PR TITLE
Codename and Date for first release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.0 'Lead Pigeon' - [07.03.2025]
+## v1.0.0 'Lead Pigeon' - [2025-03-07]
 
 Initial release of nf-core/genomeassembler, created with the [nf-core](https://nf-co.re/) template.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.0 - [date]
+## v1.0.0 'Lead Pigeon' - [07.03.2025]
 
 Initial release of nf-core/genomeassembler, created with the [nf-core](https://nf-co.re/) template.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,7 +36,7 @@ You will need to create a samplesheet with information about the samples you wou
 The largest samplesheet format is:
 
 ```csv title="samplesheet.csv"
-sample,ontreads,hifireads,ref_fasta,ref_gff,shortreads_F,shortreads_R,paired
+sample,ontreads,hifireads,ref_fasta,ref_gff,shortread_F,shortread_R,paired
 Sample1,sample1ont.fq.gz,sample1hifi.fq.gz,ref.fa,ref.gff,sample1_r1.fq.gz,sample1_r2,fq.gz
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,8 +49,8 @@ Further columns _can_ be:
   - `ref_fasta` [path] fasta file of a reference genome
   - `ref_gff` [path] annotations of the reference genome in gff format
 - Short reads
-  - `shortreads_F` : shortread forward file
-  - `shortreads_R`: shortread reverse file (paired end)
+  - `shortread_F` : shortread forward file
+  - `shortread_R`: shortread reverse file (paired end)
   - `paired`: [true/false] true if the reads are paired end, false if they are single-end. The `shortreads_R` column should exist if `paired` is `false` but can be empty.
 
 ### Multiple runs of the same sample


### PR DESCRIPTION
Now that the AWS megatest passed (https://cloud.seqera.io/orgs/nf-core/workspaces/AWSmegatests/watch/10kkZuISqYOIH6) this is hopefully the final PR before merging dev into master and creating the first release.

The PR contains final changes for the release.

- Codename and Date (planned for tomorrow; 07.03.2025) added to `changelog.md` 
- [03.07.2025] Fixed a mistake in `usage.md` where the shortread columns were named as `shortreads_[F,R]` instead of `shortread_[F,R]`

If I forgot anything please let me know :)