### PR TITLE
use correct genome-size for flye and longstitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Bugfix release
 
 ### `Fixed`
 
+[#125](https://github.com/nf-core/genomeassembler/pull/125) - use correct genome-size for flye and longstitch
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -141,7 +141,7 @@ process {
     withName: FLYE {
         ext.args = {
             [
-                params.genome_size ? "--genome-size ${params.genome_size}" : '',
+                meta.genome_size ? "--genome-size ${meta.genome_size}" : '',
                 params.flye_args
             ].join(" ").trim()
         }

--- a/modules/local/longstitch/main.nf
+++ b/modules/local/longstitch/main.nf
@@ -7,7 +7,7 @@ process LONGSTITCH {
         : 'biocontainers/longstitch:1.0.5--hdfd78af_0'}"
 
     input:
-    tuple val(meta), path(assembly), path(reads)
+    tuple val(meta), path(assembly), path(reads), val(genome_size)
 
     output:
     tuple val(meta), path("*.tigmint-ntLink-arks.fa"), emit: ntlLinks_arks_scaffolds
@@ -35,7 +35,7 @@ process LONGSTITCH {
         cp ${reads} reads.fq.gz
     fi
 
-    longstitch tigmint-ntLink-arks draft=assembly reads=reads t=${task.cpus} G=135e6 out_prefix=${prefix}
+    longstitch tigmint-ntLink-arks draft=assembly reads=reads t=${task.cpus} G=${genome_size} out_prefix=${prefix}
 
     mv *.tigmint-ntLink-arks.longstitch-scaffolds.fa ${prefix}.tigmint-ntLink-arks.fa
     sed -i 's/\\(scaffold[0-9]*\\),.*/\\1/' ${prefix}.tigmint-ntLink-arks.fa

--- a/subworkflows/local/assemble/main.nf
+++ b/subworkflows/local/assemble/main.nf
@@ -61,10 +61,10 @@ workflow ASSEMBLE {
             // Run flye
             flye_inputs
                 .join(genome_size)
-                .map { meta, reads, genomesize -> [[id: meta.id, genome_size: genomesize], reads] }
+                .map { meta, reads, genomesize -> [meta +[ genome_size: genomesize ], reads] }
                 .set { flye_inputs }
             FLYE(flye_inputs, params.flye_mode)
-            FLYE.out.fasta.map { meta, assembly -> [[id: meta.id], assembly] }.set { ch_assembly }
+            FLYE.out.fasta.map { meta, assembly -> [meta - meta.subMap('genome_size'), assembly] }.set { ch_assembly }
             ch_versions = ch_versions.mix(FLYE.out.versions)
         }
         if (params.assembler == "hifiasm") {

--- a/subworkflows/local/ont/main.nf
+++ b/subworkflows/local/ont/main.nf
@@ -4,10 +4,10 @@ include { JELLYFISH } from '../jellyfish/main'
 workflow ONT {
     take:
     input_channel
+    genome_size
 
     main:
     Channel.empty().set { ch_versions }
-    Channel.empty().set { genome_size }
     Channel.of([[],[]])
         .tap { genomescope_summary }
         .tap { genomescope_plot }

--- a/subworkflows/local/scaffolding/longstitch/main.nf
+++ b/subworkflows/local/scaffolding/longstitch/main.nf
@@ -13,17 +13,17 @@ workflow RUN_LONGSTITCH {
     _references
     ch_aln_to_ref
     meryl_kmers
+    genome_size
 
     main:
     Channel.empty().set { ch_versions }
     Channel.empty().set { quast_out }
     Channel.empty().set { busco_out }
     Channel.empty().set { merqury_report_files }
-
     assembly
         .join(in_reads)
+        .join(genome_size)
         .set { longstitch_in }
-
     LONGSTITCH(longstitch_in)
 
     LONGSTITCH.out.ntlLinks_arks_scaffolds.set { scaffolds }

--- a/subworkflows/local/scaffolding/main.nf
+++ b/subworkflows/local/scaffolding/main.nf
@@ -10,6 +10,7 @@ workflow SCAFFOLD {
     references
     ch_aln_to_ref
     meryl_kmers
+    genome_size
 
     main:
     Channel.empty().set { ch_versions }
@@ -33,7 +34,7 @@ workflow SCAFFOLD {
     }
 
     if (params.scaffold_longstitch) {
-        RUN_LONGSTITCH(inputs, in_reads, assembly, references, ch_aln_to_ref, meryl_kmers)
+        RUN_LONGSTITCH(inputs, in_reads, assembly, references, ch_aln_to_ref, meryl_kmers, genome_size)
         RUN_LONGSTITCH.out.busco_out.set { longstitch_busco }
         RUN_LONGSTITCH.out.quast_out.set { longstitch_quast }
         RUN_LONGSTITCH.out.merqury_report_files.set { longstitch_merqury }

--- a/subworkflows/local/utils_nfcore_genomeassembler_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomeassembler_pipeline/main.nf
@@ -92,7 +92,14 @@ workflow PIPELINE_INITIALISATION {
             error("Please specify which reads should be used for qc: 'ONT' or 'HIFI'")
         }
     }
-
+    // Make sure that genome_size is provided or estimated when using scaffold_longstitch
+    if (params.scaffold_longstitch) {
+        // If genomesize is not provided, and if ONT is not used in combination with jellyfish
+        // Throw an error
+        if ( !params.genome_size && (!params.ont && !params.jellyfish) ) {
+            error("Scaffolding with longstitch requires genome size.\n Either provide a genome size with --genome_size or estimate from ONT reads using jellyfish and genomescope")
+        }
+    }
     emit:
     samplesheet = ch_samplesheet
     refs = ch_refs

--- a/workflows/genomeassembler.nf
+++ b/workflows/genomeassembler.nf
@@ -142,7 +142,6 @@ workflow GENOMEASSEMBLER {
     /*
     Scaffolding
     */
-    genome_size.view()
     SCAFFOLD(ch_input, ch_longreads, ch_polished_genome, ch_refs, ch_ref_bam, meryl_kmers, genome_size)
 
     ch_versions = ch_versions.mix(SCAFFOLD.out.versions)

--- a/workflows/genomeassembler.nf
+++ b/workflows/genomeassembler.nf
@@ -82,12 +82,14 @@ workflow GENOMEASSEMBLER {
         ch_versions = ch_versions.mix(PREPARE_SHORTREADS.out.versions)
     }
 
+    ch_input.map { it -> [it.meta, params.genome_size] }
+            .set { genome_size }
 
     /*
     ONT reads
     */
     if (params.ont) {
-        ONT(ch_input)
+        ONT(ch_input, genome_size)
         ONT.out.genome_size.set { genome_size }
         ONT.out.ont_reads.set { ch_ont_reads }
 
@@ -127,7 +129,6 @@ workflow GENOMEASSEMBLER {
     ASSEMBLE.out.assembly.set { ch_polished_genome }
     ASSEMBLE.out.ref_bam.set { ch_ref_bam }
     ASSEMBLE.out.longreads.set { ch_longreads }
-
     ch_versions = ch_versions.mix(ASSEMBLE.out.versions)
     /*
     Polishing
@@ -141,8 +142,8 @@ workflow GENOMEASSEMBLER {
     /*
     Scaffolding
     */
-
-    SCAFFOLD(ch_input, ch_longreads, ch_polished_genome, ch_refs, ch_ref_bam, meryl_kmers)
+    genome_size.view()
+    SCAFFOLD(ch_input, ch_longreads, ch_polished_genome, ch_refs, ch_ref_bam, meryl_kmers, genome_size)
 
     ch_versions = ch_versions.mix(SCAFFOLD.out.versions)
 


### PR DESCRIPTION
The `longstitch` module contained a hardcoded genome-size value, an oversight that should not have made it into the release. 
While fixing this, I realized that the way `genome_size` was handled with `flye` was also bad, since it relied on changing `params.genome_size`, if there was an estimated sample-specific value from genomescope; I am not even sure that worked correctly. Generally, now the `genome_size` channel is used and either contains the value of `params.genome-size`, which can be updated with the estimated genome-size from `genomescope` in the `ONT` module.

For flye, passing genome_size is now handled by _temporarily_ storing genome_size as part of the `meta`-map, from where can be used with `ext.args` via `modules.conf`, to avoid having to patch the `flye` module. Of course, this has to be removed from `meta` afterwards to avoid breaking all later joins. 

For `longstitch`, since this is a local module, I have added genome_size to the inputs.

This closes #124. 
