### PR TITLE
fix GFA_2_FA* outputs

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -178,6 +178,20 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
+    withName: GFA_2_FA_HIFI {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/assembly/hifiasm/fasta" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+    withName: GFA_2_FA_ONT {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/assembly/hifiasm_ont/fasta" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
     withName: '.*ASSEMBLE:.*RAGTAG_PATCH' {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/assembly/ragtag/" },


### PR DESCRIPTION
GFA_2_FA_ONT and GFA_2_FA emitted into the same directory, which they should not. This is part of adding `hifiasm_on_hifiasm`, see #146.