### PR TITLE
Use CSI indexes for BAMs instead of BAI indexes.

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -271,19 +271,19 @@ The files in the alignment folder have the following base name structure:
   - `QC/`
     - `alignments/`: alignments to assemblies
       - `<SampleName>_<stage>.bam` Alignment
-      - `<SampleName>_<stage>.bai` bam index file
+      - `<SampleName>_<stage>.csi` bam index file
       - `<SampleName>_<stage>.stats` comprehensive statistics from alignment file
       - `<SampleName>_<stage>.idxstats` alignment summary statistics
       - `<SampleName>_<stage>.flagstat` number of alignments for each FLAG type
       - `shortreads/`: folder containing short read mapping for pilon
         - `<SampleName>_shortreads.bam` Alignment
-        - `<SampleName>_shortreads.bai` bam index file
+        - `<SampleName>_shortreads.csi` bam index file
         - `<SampleName>_shortreads.stats` comprehensive statistics from alignment file
         - `<SampleName>_shortreads.idxstats` alignment summary statistics
         - `<SampleName>_shortreads.flagstat` number of alignments for each FLAG type
       - `reference/`: folder containing alignment of long reads to reference
         - `<SampleName>_to_reference.bam` Alignment
-        - `<SampleName>_to_reference.bai` bam index file
+        - `<SampleName>_to_reference.csi` bam index file
         - `<SampleName>_to_reference.stats` comprehensive statistics from alignment file
         - `<SampleName>_to_reference.idxstats` alignment summary statistics
         - `<SampleName>_to_reference.flagstat` number of alignments for each FLAG type

--- a/modules/nf-core/pilon/main.nf
+++ b/modules/nf-core/pilon/main.nf
@@ -9,7 +9,7 @@ process PILON {
 
     input:
     tuple val(meta), path(fasta)
-    tuple val(meta2), path(bam), path(bai)
+    tuple val(meta2), path(bam), path(csi)
     val pilon_mode
 
     output:

--- a/modules/nf-core/samtools/flagstat/main.nf
+++ b/modules/nf-core/samtools/flagstat/main.nf
@@ -8,7 +8,7 @@ process SAMTOOLS_FLAGSTAT {
         'biocontainers/samtools:1.21--h50ea8bc_0' }"
 
     input:
-    tuple val(meta), path(bam), path(bai)
+    tuple val(meta), path(bam), path(csi)
 
     output:
     tuple val(meta), path("*.flagstat"), emit: flagstat

--- a/modules/nf-core/samtools/idxstats/main.nf
+++ b/modules/nf-core/samtools/idxstats/main.nf
@@ -8,7 +8,7 @@ process SAMTOOLS_IDXSTATS {
         'biocontainers/samtools:1.21--h50ea8bc_0' }"
 
     input:
-    tuple val(meta), path(bam), path(bai)
+    tuple val(meta), path(bam), path(csi)
 
     output:
     tuple val(meta), path("*.idxstats"), emit: idxstats

--- a/modules/nf-core/samtools/index/main.nf
+++ b/modules/nf-core/samtools/index/main.nf
@@ -11,7 +11,6 @@ process SAMTOOLS_INDEX {
     tuple val(meta), path(input)
 
     output:
-    tuple val(meta), path("*.bai") , optional:true, emit: bai
     tuple val(meta), path("*.csi") , optional:true, emit: csi
     tuple val(meta), path("*.crai"), optional:true, emit: crai
     path  "versions.yml"           , emit: versions
@@ -37,7 +36,7 @@ process SAMTOOLS_INDEX {
     stub:
     def args = task.ext.args ?: ''
     def extension = file(input).getExtension() == 'cram' ?
-                    "crai" : args.contains("-c") ?  "csi" : "bai"
+                    "crai" : "csi"
     """
     touch ${input}.${extension}
 

--- a/subworkflows/local/assemble/main.nf
+++ b/subworkflows/local/assemble/main.nf
@@ -158,7 +158,7 @@ workflow ASSEMBLE {
     */
     if (params.skip_alignments) {
         // Sample sheet layout when skipping assembly and mapping
-        // sample,ontreads,assembly,ref_fasta,ref_gff,assembly_bam,assembly_bai,ref_bam
+        // sample,ontreads,assembly,ref_fasta,ref_gff,assembly_bam,assembly_csi,ref_bam
         ch_input
             .map { row -> [row.meta, row.ref_bam] }
             .set { ch_ref_bam }

--- a/subworkflows/local/bam_sort_stat/main.nf
+++ b/subworkflows/local/bam_sort_stat/main.nf
@@ -21,12 +21,12 @@ workflow BAM_INDEX_STATS_SAMTOOLS {
 
     SAMTOOLS_INDEX(bam)
 
-    BAM_STATS_SAMTOOLS(bam.join(SAMTOOLS_INDEX.out.bai, by: [0]), fasta)
+    BAM_STATS_SAMTOOLS(bam.join(SAMTOOLS_INDEX.out.csi, by: [0]), fasta)
 
     versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions).mix(BAM_STATS_SAMTOOLS.out.versions)
 
     emit:
-    bai = SAMTOOLS_INDEX.out.bai // channel: [ val(meta), [ bai ] ]
+    csi = SAMTOOLS_INDEX.out.csi // channel: [ val(meta), [ csi ] ]
     stats = BAM_STATS_SAMTOOLS.out.stats // channel: [ val(meta), [ stats ] ]
     flagstat = BAM_STATS_SAMTOOLS.out.flagstat // channel: [ val(meta), [ flagstat ] ]
     idxstats = BAM_STATS_SAMTOOLS.out.idxstats // channel: [ val(meta), [ idxstats ] ]

--- a/subworkflows/local/mapping/map_sr/main.nf
+++ b/subworkflows/local/mapping/map_sr/main.nf
@@ -14,33 +14,33 @@ workflow MAP_SR {
         .join(genome_assembly)
         .set { map_assembly }
 
-    ALIGN_SHORT(map_assembly, true, 'bai', false, false)
+    ALIGN_SHORT(map_assembly, true, 'csi', false, false)
 
     versions = ch_versions.mix(ALIGN_SHORT.out.versions)
 
     ALIGN_SHORT.out.bam.set { aln_to_assembly_bam }
 
-    ALIGN_SHORT.out.index.set { aln_to_assembly_bai }
+    ALIGN_SHORT.out.index.set { aln_to_assembly_csi }
 
     aln_to_assembly_bam
-        .join(aln_to_assembly_bai)
-        .set { aln_to_assembly_bam_bai }
+        .join(aln_to_assembly_csi)
+        .set { aln_to_assembly_bam_csi }
 
     map_assembly
         .map { meta, _reads, fasta -> [ meta, fasta ] }
         .set { ch_fasta }
 
-    BAM_STATS(aln_to_assembly_bam_bai, ch_fasta)
+    BAM_STATS(aln_to_assembly_bam_csi, ch_fasta)
 
     versions = ch_versions.mix(BAM_STATS.out.versions)
 
     aln_to_assembly_bam
-        .join(aln_to_assembly_bai)
-        .set { aln_to_assembly_bam_bai }
+        .join(aln_to_assembly_csi)
+        .set { aln_to_assembly_bam_csi }
 
     emit:
     aln_to_assembly_bam
-    aln_to_assembly_bai
-    aln_to_assembly_bam_bai
+    aln_to_assembly_csi
+    aln_to_assembly_bam_csi
     versions
 }

--- a/subworkflows/local/mapping/map_to_assembly/main.nf
+++ b/subworkflows/local/mapping/map_to_assembly/main.nf
@@ -13,20 +13,20 @@ workflow MAP_TO_ASSEMBLY {
         .join(genome_assembly)
         .set { map_assembly }
 
-    ALIGN(map_assembly, true, 'bai', false, false)
+    ALIGN(map_assembly, true, 'csi', false, false)
 
     ALIGN.out.bam.set { aln_to_assembly_bam }
-    ALIGN.out.index.set { aln_to_assembly_bai }
+    ALIGN.out.index.set { aln_to_assembly_csi }
 
     map_assembly
         .map { meta, _reads, fasta -> [meta, fasta] }
         .set { ch_fasta }
 
     aln_to_assembly_bam
-        .join(aln_to_assembly_bai)
-        .set { aln_to_assembly_bam_bai }
+        .join(aln_to_assembly_csi)
+        .set { aln_to_assembly_bam_csi }
 
-    BAM_STATS(aln_to_assembly_bam_bai, ch_fasta )
+    BAM_STATS(aln_to_assembly_bam_csi, ch_fasta )
 
     versions = ch_versions.mix(ALIGN.out.versions).mix(BAM_STATS.out.versions)
 

--- a/subworkflows/local/mapping/map_to_ref/main.nf
+++ b/subworkflows/local/mapping/map_to_ref/main.nf
@@ -13,19 +13,19 @@ workflow MAP_TO_REF {
         .join(ch_refs)
         .set { ch_map_ref_in }
 
-    ALIGN(ch_map_ref_in, true, 'bai', false, false)
+    ALIGN(ch_map_ref_in, true, 'csi', false, false)
 
     ALIGN.out.bam.set { ch_aln_to_ref_bam }
 
     ch_aln_to_ref_bam
         .join(ALIGN.out.index)
-        .set { ch_aln_to_ref_bam_bai }
+        .set { ch_aln_to_ref_bam_csi }
 
     ch_map_ref_in
         .map { meta, _reads, fasta -> [meta, fasta] }
         .set { ch_fasta }
 
-    BAM_STATS(ch_aln_to_ref_bam_bai, ch_fasta)
+    BAM_STATS(ch_aln_to_ref_bam_csi, ch_fasta)
 
     versions = ch_versions.mix(ALIGN.out.versions).mix(BAM_STATS.out.versions)
 

--- a/subworkflows/local/polishing/pilon/polish_pilon/main.nf
+++ b/subworkflows/local/polishing/pilon/polish_pilon/main.nf
@@ -19,7 +19,7 @@ workflow POLISH_PILON {
 
     ch_versions = ch_versions.mix(MAP_SR.out.versions)
 
-    RUN_PILON(assembly, MAP_SR.out.aln_to_assembly_bam_bai)
+    RUN_PILON(assembly, MAP_SR.out.aln_to_assembly_bam_csi)
 
     RUN_PILON.out.improved_assembly.set { pilon_polished }
 

--- a/subworkflows/local/polishing/pilon/run_pilon/main.nf
+++ b/subworkflows/local/polishing/pilon/run_pilon/main.nf
@@ -3,15 +3,15 @@ include { PILON } from '../../../../../modules/nf-core/pilon/main'
 workflow RUN_PILON {
     take:
     assembly_in
-    aln_to_assembly_bam_bai
+    aln_to_assembly_bam_csi
 
     main:
     assembly_in
-        .join(aln_to_assembly_bam_bai)
+        .join(aln_to_assembly_bam_csi)
         .set { pilon_in }
     PILON(
-        pilon_in.map { meta, assembly, _bam, _bai -> [meta, assembly] },
-        pilon_in.map { meta, _assembly, bam, bai -> [meta, bam, bai] },
+        pilon_in.map { meta, assembly, _bam, _csi -> [meta, assembly] },
+        pilon_in.map { meta, _assembly, bam, csi -> [meta, bam, csi] },
         "bam",
     )
     versions = PILON.out.versions

--- a/subworkflows/nf-core/bam_sort_stats_samtools/main.nf
+++ b/subworkflows/nf-core/bam_sort_stats_samtools/main.nf
@@ -22,24 +22,15 @@ workflow BAM_SORT_STATS_SAMTOOLS {
     ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions.first())
 
     SAMTOOLS_SORT.out.bam
-        .join(SAMTOOLS_INDEX.out.bai, by: [0], remainder: true)
         .join(SAMTOOLS_INDEX.out.csi, by: [0], remainder: true)
-        .map {
-            meta, bam, bai, csi ->
-                if (bai) {
-                    [ meta, bam, bai ]
-                } else {
-                    [ meta, bam, csi ]
-                }
-        }
-        .set { ch_bam_bai }
+        .map { meta, bam, csi -> [ meta, bam, csi ] }
+        .set { ch_bam_csi }
 
-    BAM_STATS_SAMTOOLS ( ch_bam_bai, ch_fasta )
+    BAM_STATS_SAMTOOLS ( ch_bam_csi, ch_fasta )
     ch_versions = ch_versions.mix(BAM_STATS_SAMTOOLS.out.versions)
 
     emit:
     bam      = SAMTOOLS_SORT.out.bam           // channel: [ val(meta), [ bam ] ]
-    bai      = SAMTOOLS_INDEX.out.bai          // channel: [ val(meta), [ bai ] ]
     csi      = SAMTOOLS_INDEX.out.csi          // channel: [ val(meta), [ csi ] ]
 
     stats    = BAM_STATS_SAMTOOLS.out.stats    // channel: [ val(meta), [ stats ] ]

--- a/subworkflows/nf-core/bam_stats_samtools/main.nf
+++ b/subworkflows/nf-core/bam_stats_samtools/main.nf
@@ -8,19 +8,19 @@ include { SAMTOOLS_FLAGSTAT } from '../../../modules/nf-core/samtools/flagstat/m
 
 workflow BAM_STATS_SAMTOOLS {
     take:
-    ch_bam_bai // channel: [ val(meta), path(bam), path(bai) ]
+    ch_bam_csi // channel: [ val(meta), path(bam), path(csi) ]
     ch_fasta   // channel: [ val(meta), path(fasta) ]
 
     main:
     ch_versions = Channel.empty()
 
-    SAMTOOLS_STATS ( ch_bam_bai, ch_fasta )
+    SAMTOOLS_STATS ( ch_bam_csi, ch_fasta )
     ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions)
 
-    SAMTOOLS_FLAGSTAT ( ch_bam_bai )
+    SAMTOOLS_FLAGSTAT ( ch_bam_csi )
     ch_versions = ch_versions.mix(SAMTOOLS_FLAGSTAT.out.versions)
 
-    SAMTOOLS_IDXSTATS ( ch_bam_bai )
+    SAMTOOLS_IDXSTATS ( ch_bam_csi )
     ch_versions = ch_versions.mix(SAMTOOLS_IDXSTATS.out.versions)
 
     emit:


### PR DESCRIPTION
<!--
# nf-core/genomeassembler pull request

Many thanks for contributing to nf-core/genomeassembler!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/genomeassembler/tree/master/.github/CONTRIBUTING.md)
-->

While running the dev version of this pipeline I managed to produce a large contig. This produced error:

```
  [E::hts_idx_check_range] Region 536854800..536872065 cannot be stored in a bai index. Try using a csi index
```

As such, this PR aims to replace the default bai index with a csi index to avoid this error. 

## PR checklist
 
- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated. (this is not a full release so I did not update changeling)
- [ ] `README.md` is updated (including new tool citations and authors/contributors). (not sure this merits any change to the readme either)
