### PR TITLE
Fix: Nextflow >=26.04 strict parsing bugs

### DIFF
--- a/modules/local/genomescope/main.nf
+++ b/modules/local/genomescope/main.nf
@@ -13,7 +13,7 @@ process GENOMESCOPE {
         tuple val(meta), path("*_genomescope.txt")  , emit: summary
         tuple val(meta), path("*_plot.log.png")     , emit: plot_log
         tuple val(meta), path("*_plot.png")         , emit: plot
-        tuple val(meta), env(est_hap_len)           , emit: estimated_hap_len
+        tuple val(meta), env('est_hap_len')           , emit: estimated_hap_len
         path "versions.yml"                         , emit: versions
 
     script:

--- a/modules/local/nanoq/main.nf
+++ b/modules/local/nanoq/main.nf
@@ -13,7 +13,7 @@ process NANOQ {
     output:
     tuple val(meta), path("*_report.json"), emit: report
     tuple val(meta), path("*_stats.json"), emit: stats
-    tuple val(meta), env(median), emit: median_length
+    tuple val(meta), env('median'), emit: median_length
     path "versions.yml", emit: versions
 
     script:

--- a/nextflow.config
+++ b/nextflow.config
@@ -332,33 +332,6 @@ plugins {
 
 validation {
     defaultIgnoreParams = ["genomes"]
-    help {
-        enabled = true
-        command = "nextflow run $manifest.name -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
-        fullParameter = "help_full"
-        showHiddenParameter = "show_hidden"
-        beforeText = """
--\033[2m----------------------------------------------------\033[0m-
-                                        \033[0;32m,--.\033[0;30m/\033[0;32m,-.\033[0m
-\033[0;34m        ___     __   __   __   ___     \033[0;32m/,-._.--~\'\033[0m
-\033[0;34m  |\\ | |__  __ /  ` /  \\ |__) |__         \033[0;33m}  {\033[0m
-\033[0;34m  | \\| |       \\__, \\__/ |  \\ |___     \033[0;32m\\`-._,-`-,\033[0m
-                                        \033[0;32m`._,._,\'\033[0m
-\033[0;35m  ${manifest.name} ${manifest.version}\033[0m
--\033[2m----------------------------------------------------\033[0m-
-"""
-        afterText = """${manifest.doi ? "* The pipeline\n" : ""}${manifest.doi.tokenize(",").collect { "  https://doi.org/${it.trim().replace('https://doi.org/','')}"}.join("\n")}${manifest.doi ? "\n" : ""}
-* The nf-core framework
-    https://doi.org/10.1038/s41587-020-0439-x
-
-* Software dependencies
-    https://github.com/${manifest.name}/blob/master/CITATIONS.md
-"""
-    }
-    summary {
-        beforeText = validation.help.beforeText
-        afterText = validation.help.afterText
-    }
 }
 
 // Load modules.config for DSL2 module specific options

--- a/nextflow.config
+++ b/nextflow.config
@@ -286,22 +286,21 @@ process.shell = [
 // Disable process selector warnings by default. Use debug profile to enable warnings.
 nextflow.enable.configProcessNamesValidation = false
 
-def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_timeline_${trace_timestamp}.html"
+    file    = "${params.outdir}/pipeline_info/execution_timeline_${params.trace_report_suffix}.html"
 }
 report {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_report_${trace_timestamp}.html"
+    file    = "${params.outdir}/pipeline_info/execution_report_${params.trace_report_suffix}.html"
 }
 trace {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_trace_${trace_timestamp}.txt"
+    file    = "${params.outdir}/pipeline_info/execution_trace_${params.trace_report_suffix}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/pipeline_dag_${trace_timestamp}.html"
+    file    = "${params.outdir}/pipeline_info/pipeline_dag_${params.trace_report_suffix}.html"
 }
 
 manifest {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -148,6 +148,12 @@
                     "description": "Base URL or local path to location of pipeline test dataset files",
                     "default": "https://raw.githubusercontent.com/nf-core/test-datasets/",
                     "hidden": true
+                },
+                "trace_report_suffix": {
+                    "type": "string",
+                    "fa_icon": "far calendar",
+                    "description": "Suffix to add to the trace report filename. Default is the date and time in the format yyyy-MM-dd_HH-mm-ss.",
+                    "hidden": true
                 }
             }
         },


### PR DESCRIPTION
# Description

Fixes bugs that cause errors on `nextflow inspect` and `nextflow run` with Nextflow >= 26.04 due to the [enforcement of strict syntax](https://docs.seqera.io/nextflow/strict-syntax#preparing-for-strict-syntax).

The first parsing error involved a variable definition in a config file.

```bash

Error nextflow.config:289:1: Variable declarations cannot be mixed with config statements
│ 289 | def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-s
╰     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


ERROR ~ Config parsing failed


```

Other errors included config variable references and file and missing quote marks in `env()` calls. A warning on `params.trace_report_suffix` was fixed by adding the variable to nextflow_schema.json.

The fixes were based on the nf-core/taxprofiler pipeline.

This is an immediate fix for pipeline execution and is not a comprehensive migration to the strict syntax.

# Tests

Tested on Nextflow 26.04.2.12216 and 26.04.3.12259 with the command

```bash
# custom.config only sets CPU and RAM usage limits for my development machine
nextflow run main.nf -profile test,singularity -c custom.config --outdir results
```
