### PR TITLE
Used trimmed reads with jellyfish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ In addition, v2.0.0 contains these changes:
 
 Pull requests in reverse chronological order since v1.1.0
 
+[#197](https://github.com/nf-core/genomeassembler/pull/197)
+
+- Fix handling of reads for quality control, inputs for jellyfish should be trimmed.
+
 [#196](https://github.com/nf-core/genomeassembler/pull/196)
 
 - bgzip `medaka` outputs

--- a/subworkflows/local/prepare/main.nf
+++ b/subworkflows/local/prepare/main.nf
@@ -153,15 +153,16 @@ workflow PREPARE {
                 it -> it.meta.hifireads ? false : true
             }
         )
+        // update the path to QC reads, so that the trimmed reads will be used.
         .map {
-            meta ->
+            it ->
             [
-                meta: meta -
-                    meta.subMap("qc_reads_path") +
+                meta: it.meta -
+                    it.meta.subMap("qc_reads_path") +
                     [
-                        qc_reads_path: meta.qc_reads.toLowerCase() == "ont" ?
-                            meta.ontreads :
-                            meta.hifireads
+                        qc_reads_path: it.meta.qc_reads.toLowerCase() == "ont" ?
+                            it.meta.ontreads :
+                            it.meta.hifireads
                     ]
             ]
         }

--- a/subworkflows/local/prepare/main.nf
+++ b/subworkflows/local/prepare/main.nf
@@ -153,6 +153,18 @@ workflow PREPARE {
                 it -> it.meta.hifireads ? false : true
             }
         )
+        .map {
+            meta ->
+            [
+                meta: meta -
+                    meta.subMap("qc_reads_path") +
+                    [
+                        qc_reads_path: meta.qc_reads.toLowerCase() == "ont" ?
+                            meta.ontreads :
+                            meta.hifireads
+                    ]
+            ]
+        }
 
     // Get average read length of the QC reads from fastplong json report
     def slurp = new groovy.json.JsonSlurper()
@@ -177,13 +189,15 @@ workflow PREPARE {
             .filter { it -> it.meta.qc_reads.toLowerCase() == "hifi" }
             .map {
                 it -> [
-                    it.meta.id, it.meta - it.meta.subMap("fastplong_json")]}
+                    it.meta.id, it.meta - it.meta.subMap("fastplong_json")
+                    ]
+                }
             .join(
                 HIFI.out.fastplong_hifi_reports
                     .map { it -> [ it[0].id, it[1] ]}
             )
             .map {
-            _id, meta_old, json -> [meta: meta_old + [fastplong_json: json]]
+                _id, meta_old, json -> [meta: meta_old + [fastplong_json: json]]
             }
         )
         .map { it ->
@@ -212,18 +226,6 @@ workflow PREPARE {
 
     main_out = ch_main_jellyfish_branched.no_jelly
         .mix( JELLYFISH.out.main_out )
-        // At this stage, make sure that qc_read_path for downstream qc is using the prepared reads.
-        .map { it ->
-            [
-                meta:   it.meta -
-                        it.meta.subMap("qc_read_path") +
-                        [
-                            qc_read_path: it.meta.qc_reads.toLowerCase() == "ont" ?
-                            it.meta.ontreads :
-                            it.meta.hifireads
-                        ]
-            ]
-        }
 
     main_out.dump(tag: "Prepare: Combined outputs")
 


### PR DESCRIPTION
Jellyfish should receive trimmed reads, and not take the raw reads. 
To do this, `qc_reads_path` needs to be updated to the trimmed reads after preparing the input files. Previously, this update happened after Jellyfish, which was too late.