### PR TITLE
bump medaka to 2.2.2, closes #204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,6 @@ The following tools are unchanged:
 | coreutils  | 9.5    | 9.5    |
 | jellyfish  | 2.3.1  | 2.3.1  |
 | longstitch | 1.0.5  | 1.0.5  |
-| medaka     | 1.11.3 | 1.11.3 |
 | quast      | 5.3.0  | 5.3.0  |
 | quarto     | 1.7.31 | 1.7.31 |
 | fastqc     | 0.12.1 | 0.12.1 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ In addition, v2.0.0 contains these changes:
 
 Pull requests in reverse chronological order since v1.1.0
 
+[#212](https://github.com/nf-core/genomeassembler/pull/212)
+
+- bumped medaka to 2.2.2
+
 [#207](https://github.com/nf-core/genomeassembler/pull/207)
 
 - additional tests for QC modules
@@ -120,6 +124,7 @@ The following tools have been updated to a new version:
 | ------------ | ------ | ------ |
 | genomescope2 | 2.0    | 2.0.0  |
 | busco        | 5.8.3  | 6.0.0  |
+| medaka       | 2.0.1  | 2.2.2  |
 
 #### `Deprecated`
 

--- a/modules/local/medaka/main.nf
+++ b/modules/local/medaka/main.nf
@@ -5,9 +5,9 @@ process MEDAKA {
     label 'process_long'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/medaka:1.11.3--py310h87e71ce_0'
-        : 'biocontainers/medaka:1.11.3--py310h87e71ce_0'}"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container  ?
+        'https://depot.galaxyproject.org/singularity/biocontainers/medaka:2.2.2--py312h3050eb1_0' :
+        'biocontainers/medaka:2.2.2--py312h3050eb1_0'}"
 
     input:
     tuple val(meta), path(reads), path(assembly)

--- a/modules/local/medaka/main.nf
+++ b/modules/local/medaka/main.nf
@@ -6,7 +6,7 @@ process MEDAKA {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container  ?
-        'https://depot.galaxyproject.org/singularity/biocontainers/medaka:2.2.2--py312h3050eb1_0' :
+        'https://depot.galaxyproject.org/singularity/medaka:2.2.2--py312h3050eb1_0' :
         'biocontainers/medaka:2.2.2--py312h3050eb1_0'}"
 
     input:

--- a/modules/local/medaka/medaka_consensus/environment.yml
+++ b/modules/local/medaka/medaka_consensus/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::medaka=2.0.1
+  - bioconda::medaka=2.2.2

--- a/modules/local/medaka/medaka_consensus/main.nf
+++ b/modules/local/medaka/medaka_consensus/main.nf
@@ -4,9 +4,9 @@ process MEDAKA_PARALLEL {
     label 'process_long'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/medaka:2.0.1--py310he807b20_0'
-        : 'biocontainers/medaka:2.0.1--py310he807b20_0'}"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container  ?
+        'https://depot.galaxyproject.org/singularity/biocontainers/medaka:2.2.2--py312h3050eb1_0' :
+        'biocontainers/medaka:2.2.2--py312h3050eb1_0'}"
 
     input:
     tuple val(meta), path(reads), path(assembly)

--- a/modules/local/medaka/medaka_consensus/main.nf
+++ b/modules/local/medaka/medaka_consensus/main.nf
@@ -5,7 +5,7 @@ process MEDAKA_PARALLEL {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container  ?
-        'https://depot.galaxyproject.org/singularity/biocontainers/medaka:2.2.2--py312h3050eb1_0' :
+        'https://depot.galaxyproject.org/singularity/medaka:2.2.2--py312h3050eb1_0' :
         'biocontainers/medaka:2.2.2--py312h3050eb1_0'}"
 
     input:


### PR DESCRIPTION
As suggested in #204 , this updates medaka to version `2.2.2`
