### PR TITLE
Pipeline object storage fix

### DIFF
--- a/conf/modules/QC/alignments.config
+++ b/conf/modules/QC/alignments.config
@@ -52,6 +52,23 @@ process {
             (meta.qc_reads == 'ont' ? "-ax lr:hq" : "-ax map-hifi")
         }
     }
+    withName: '.*DORADO:.*MAP_TO_ASSEMBLY.*' {
+        ext.prefix = { "${meta.id}_dorado" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/alignments/" },
+            mode: params.publish_dir_mode
+        ]
+    }
+    withName: '.*DORADO:.*MAP_TO_ASSEMBLY.*:ALIGN' {
+        ext.prefix = { "${meta.id}_dorado" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/alignments/" },
+            mode: params.publish_dir_mode
+        ]
+        ext.args = {
+            (meta.qc_reads == 'ont' ? "-ax lr:hq" : "-ax map-hifi")
+        }
+    }
     withName: '.*PILON:.*MAP_TO_ASSEMBLY.*' {
         ext.prefix = { "${meta.id}_pilon" }
         publishDir = [

--- a/conf/modules/QC/busco.config
+++ b/conf/modules/QC/busco.config
@@ -23,6 +23,14 @@ process {
             pattern: "*{-busco,_summary}*"
         ]
     }
+    withName: '.*DORADO:.*:BUSCO' {
+        ext.prefix = { "${meta.id}_dorado-${lineage}" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/BUSCO/" },
+            mode: params.publish_dir_mode,
+            pattern: "*{-busco,_summary}*"
+        ]
+    }
     withName: '.*LINKS:.*:BUSCO' {
         ext.prefix = { "${meta.id}_links-${lineage}" }
         publishDir = [

--- a/conf/modules/QC/quast.config
+++ b/conf/modules/QC/quast.config
@@ -3,8 +3,6 @@ process {
         ext.prefix = { "${meta.id}_assembly" }
         ext.args = {
             [
-                    meta.ref_map_bam ? "--ref-bam ${meta.ref_map_bam}" : '',
-                    meta.assembly_map_bam ? "--bam ${meta.assembly_map_bam}": '',
                     '--glimmer',
                     '--large'
             ]
@@ -19,8 +17,6 @@ process {
         ext.prefix = { "${meta.id}_pilon" }
         ext.args = {
             [
-                    meta.ref_map_bam ? "--ref-bam ${meta.ref_map_bam}" : '',
-                    meta.assembly_map_bam ? "--bam ${meta.assembly_map_bam}": '',
                     '--glimmer',
                     '--large'
             ]
@@ -35,8 +31,6 @@ process {
         ext.prefix = { "${meta.id}_medaka" }
         ext.args = {
             [
-                    meta.ref_map_bam ? "--ref-bam ${meta.ref_map_bam}" : '',
-                    meta.assembly_map_bam ? "--bam ${meta.assembly_map_bam}": '',
                     '--glimmer',
                     '--large'
             ]
@@ -51,8 +45,6 @@ process {
         ext.prefix = { "${meta.id}_links" }
         ext.args = {
             [
-                    meta.ref_map_bam ? "--ref-bam ${meta.ref_map_bam}" : '',
-                    meta.assembly_map_bam ? "--bam ${meta.assembly_map_bam}": '',
                     '--glimmer',
                     '--large'
             ]
@@ -67,8 +59,6 @@ process {
         ext.prefix = { "${meta.id}_longstitch" }
         ext.args = {
             [
-                    meta.ref_map_bam ? "--ref-bam ${meta.ref_map_bam}" : '',
-                    meta.assembly_map_bam ? "--bam ${meta.assembly_map_bam}": '',
                     '--glimmer',
                     '--large'
             ]
@@ -83,8 +73,6 @@ process {
         ext.prefix = { "${meta.id}_yahs" }
         ext.args = {
             [
-                    meta.ref_map_bam ? "--ref-bam ${meta.ref_map_bam}" : '',
-                    meta.assembly_map_bam ? "--bam ${meta.assembly_map_bam}": '',
                     '--glimmer',
                     '--large'
             ]
@@ -100,8 +88,6 @@ process {
         ext.prefix = { "${meta.id}_ragtag" }
         ext.args = {
             [
-                    meta.ref_map_bam ? "--ref-bam ${meta.ref_map_bam}" : '',
-                    meta.assembly_map_bam ? "--bam ${meta.assembly_map_bam}": '',
                     '--glimmer',
                     '--large'
             ]

--- a/conf/modules/QC/quast.config
+++ b/conf/modules/QC/quast.config
@@ -41,6 +41,20 @@ process {
             mode: params.publish_dir_mode
         ]
     }
+    withName: '.*DORADO:.*:QUAST' {
+        ext.prefix = { "${meta.id}_dorado" }
+        ext.args = {
+            [
+                    '--glimmer',
+                    '--large'
+            ]
+            .join(" ")
+        }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/QC/QUAST" },
+            mode: params.publish_dir_mode
+        ]
+    }
     withName: '.*LINKS:.*:QUAST' {
         ext.prefix = { "${meta.id}_links" }
         ext.args = {

--- a/modules.json
+++ b/modules.json
@@ -131,7 +131,8 @@
                     "quast": {
                         "branch": "master",
                         "git_sha": "9a034dd2c5df2c9b283e09ddf2667d9118b4ccd7",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/quast/quast.diff"
                     },
                     "ragtag/patch": {
                         "branch": "master",

--- a/modules/nf-core/quast/main.nf
+++ b/modules/nf-core/quast/main.nf
@@ -11,6 +11,8 @@ process QUAST {
     tuple val(meta) , path(consensus)
     tuple val(meta2), path(fasta)
     tuple val(meta3), path(gff)
+    tuple val(meta4), path(ref_map_bam)
+    tuple val(meta5), path(assembly_map_bam)
 
     output:
     tuple val(meta), path("${prefix}")                   , emit: results
@@ -24,16 +26,20 @@ process QUAST {
     task.ext.when == null || task.ext.when
 
     script:
-    def args      = task.ext.args   ?: ''
-    prefix        = task.ext.prefix ?: "${meta.id}"
-    def features  = gff             ?  "--features $gff" : ''
-    def reference = fasta           ?  "-r $fasta"       : ''
+    def args      = task.ext.args       ?: ''
+    prefix        = task.ext.prefix     ?: "${meta.id}"
+    def features  = gff                 ?  "--features $gff" : ''
+    def reference = fasta               ?  "-r $fasta"       : ''
+    def ref_bam   = ref_map_bam         ?  "--ref-bam ${ref_map_bam}" : ''
+    def ass_bam   = assembly_map_bam    ?  "--bam ${assembly_map_bam}" : ''
     """
     quast.py \\
         --output-dir $prefix \\
         $reference \\
         $features \\
         --threads $task.cpus \\
+        $ref_bam \\
+        $ass_bam \\
         $args \\
         ${consensus.join(' ')}
 

--- a/modules/nf-core/quast/quast.diff
+++ b/modules/nf-core/quast/quast.diff
@@ -1,0 +1,44 @@
+Changes in component 'nf-core/quast'
+'modules/nf-core/quast/environment.yml' is unchanged
+'modules/nf-core/quast/meta.yml' is unchanged
+Changes in 'quast/main.nf':
+--- modules/nf-core/quast/main.nf
++++ modules/nf-core/quast/main.nf
+@@ -11,6 +11,8 @@
+     tuple val(meta) , path(consensus)
+     tuple val(meta2), path(fasta)
+     tuple val(meta3), path(gff)
++    tuple val(meta4), path(ref_map_bam)
++    tuple val(meta5), path(assembly_map_bam)
+ 
+     output:
+     tuple val(meta), path("${prefix}")                   , emit: results
+@@ -24,16 +26,20 @@
+     task.ext.when == null || task.ext.when
+ 
+     script:
+-    def args      = task.ext.args   ?: ''
+-    prefix        = task.ext.prefix ?: "${meta.id}"
+-    def features  = gff             ?  "--features $gff" : ''
+-    def reference = fasta           ?  "-r $fasta"       : ''
++    def args      = task.ext.args       ?: ''
++    prefix        = task.ext.prefix     ?: "${meta.id}"
++    def features  = gff                 ?  "--features $gff" : ''
++    def reference = fasta               ?  "-r $fasta"       : ''
++    def ref_bam   = ref_map_bam         ?  "--ref-bam ${ref_map_bam}" : ''
++    def ass_bam   = assembly_map_bam    ?  "--bam ${assembly_map_bam}" : ''
+     """
+     quast.py \\
+         --output-dir $prefix \\
+         $reference \\
+         $features \\
+         --threads $task.cpus \\
++        $ref_bam \\
++        $ass_bam \\
+         $args \\
+         ${consensus.join(' ')}
+ 
+
+'modules/nf-core/quast/tests/main.nf.test' is unchanged
+'modules/nf-core/quast/tests/main.nf.test.snap' is unchanged
+************************************************************

--- a/subworkflows/local/qc/main.nf
+++ b/subworkflows/local/qc/main.nf
@@ -92,9 +92,11 @@ workflow QC {
                 ]
                 use_ref: [it.meta, it.meta.use_ref ? it.meta.ref_fasta : []]
                 use_gff: [it.meta, it.meta.use_ref && it.meta.ref_gff ? it.meta.ref_gff : []]
+                ref_bam: [it.meta, it.meta.ref_map_bam ?: []]
+                assembly_bam: [it.meta, it.meta.assembly_map_bam ?: []]
             }
 
-    QUAST(quast_in.quast_in, quast_in.use_ref, quast_in.use_gff)
+    QUAST(quast_in.quast_in, quast_in.use_ref, quast_in.use_gff, quast_in.ref_bam, quast_in.assembly_bam)
     quast_out = QUAST.out.tsv
 
     busco_in = ch_qc


### PR DESCRIPTION
This fixes a bug that was discovered during AWS testing, which revealed that the way that some files were conditionally smuggled into quast, via `ext.args`, fails with object storage. The quast module has been patched to take those as inputs, QC subworkflow now passes those as inputs. The files are no longer passed via config.

Edit: reported in #220 