### PR TITLE
test meryl/merqury in full AWS test

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -35,5 +35,6 @@ params {
     jellyfish           = true
     use_ref             = true
     shortread_trim      = true
+    merqury             = true
     busco_lineage       = "brassicales_odb12"
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -101,7 +101,7 @@ params {
     // -- Polish: pilon
     polish_pilon               = false // run pilon
     // -- QC --
-    // -- QC : Meryl, automatically enabled with short-reads
+    // -- QC : Meryl
     meryl_k                    = 21 // k for meryl
     merqury                    = false
     // -- QC : Busco


### PR DESCRIPTION
QC with merqury was disabled in AWS full tests, this PR fixes that.
