### PR TITLE
retry LINKS if exitcode == 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@ Pull requests in reverse chronological order since v1.1.0
 
 - Fixed typo in medaka url (@TomHarrop)
 
+[#223](https://github.com/nf-core/genomeassembler/issues/223)
+
+- Add exitcode `2` as retry code for links in AWS fulltest profile.
+
 ### `Dependencies`
 
 #### New

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -38,3 +38,10 @@ params {
     merqury             = true
     busco_lineage       = "brassicales_odb12"
 }
+
+process {
+    withName: '.*LINKS' {
+        errorStrategy = { task.exitStatus in ((130..145) + 104 + (175..177) + 2) ? 'retry' : 'finish' }
+
+    }
+}


### PR DESCRIPTION
This PR adds exitcode 2 as a retry code for LINKS.

During AWS full test, this error occured:

```
Caused by:
  Essential container in task exited - OutOfMemoryError: Container killed due to memory usage
``` 

However, LINKS appears to not report this with an exitcode that indicates OOM, instead, LINKS exits with `2`:

```
Command exit status:
  2
```

