### PR TITLE
fix buggy meta-map in scaffold outputs

### DIFF
--- a/subworkflows/local/scaffold/main.nf
+++ b/subworkflows/local/scaffold/main.nf
@@ -92,9 +92,16 @@ workflow SCAFFOLD {
                 )
                 .map {
                     _id, meta_links, meta_longstitch ->
-                        meta_links -
-                         meta_links.subMap("scaffolds_links") +
-                         [scaffolds: [links: meta_links.scaffolds_links, longstitch: meta_longstitch.scaffolds_longstitch]]
+                    [
+                        meta:   meta_links -
+                                meta_links.subMap("scaffolds_links") +
+                                [
+                                    scaffolds: [
+                                        links: meta_links.scaffolds_links,
+                                        longstitch: meta_longstitch.scaffolds_longstitch
+                                        ]
+                                ]
+                    ]
                 }
         )
         //links-ragtag
@@ -109,9 +116,16 @@ workflow SCAFFOLD {
                 )
                 .map {
                     _id, meta_links, meta_ragtag ->
-                        meta_links -
-                         meta_links.subMap("scaffolds_links") +
-                         [ scaffolds: [ links: meta_links.scaffolds_links, ragtag: meta_ragtag.scaffolds_ragtag ] ]
+                    [
+                     meta:  meta_links -
+                            meta_links.subMap("scaffolds_links") +
+                            [
+                                scaffolds: [
+                                    links: meta_links.scaffolds_links,
+                                    ragtag: meta_ragtag.scaffolds_ragtag
+                                ]
+                            ]
+                    ]
                 }
         )
         //longstitch-ragtag
@@ -125,10 +139,16 @@ workflow SCAFFOLD {
                         .map {it -> [it.meta.id, it.meta]}
                 )
                 .map {
-                    _id, meta_longstitch, meta_ragtag ->
-                        meta_longstitch -
-                         meta_longstitch.subMap("scaffolds_longstitch") +
-                         [scaffolds: [ longstitch: meta_longstitch.scaffolds_longstitch, ragtag: meta_ragtag.scaffolds_ragtag ] ]
+                    _id, meta_longstitch, meta_ragtag -> [
+                        meta:   meta_longstitch -
+                                meta_longstitch.subMap("scaffolds_longstitch") +
+                                [
+                                    scaffolds: [
+                                        longstitch: meta_longstitch.scaffolds_longstitch,
+                                        ragtag: meta_ragtag.scaffolds_ragtag
+                                    ]
+                                ]
+                    ]
                 }
         )
         // mix in triple-scaffolded
@@ -146,16 +166,17 @@ workflow SCAFFOLD {
                         .map {it -> [it.meta.id, it.meta]}
                 )
                 .map {
-                    _id, meta_links, meta_longstitch, meta_ragtag ->
-                         meta_links -
-                         meta_links.subMap("scaffolds_links") +
-                            [
-                                scaffolds: [
-                                links: meta_links.scaffolds_links,
-                                longstitch: meta_longstitch.scaffolds_longstitch,
-                                ragtag: meta_ragtag.scaffolds_ragtag
+                    _id, meta_links, meta_longstitch, meta_ragtag -> [
+                        meta:   meta_links -
+                                meta_links.subMap("scaffolds_links") +
+                                [
+                                    scaffolds: [
+                                        links: meta_links.scaffolds_links,
+                                        longstitch: meta_longstitch.scaffolds_longstitch,
+                                        ragtag: meta_ragtag.scaffolds_ragtag
+                                    ]
                                 ]
-                            ]
+                    ]
                 }
         )
 


### PR DESCRIPTION
AWS fulltest failed, again. This time with
```
Cannot get property 'strategy' on null object
```

With seqera AI, this was traced to the `scaffold` swf, an issue which should have been fixed before, but was only fixed for the first couple of cases [#215](https://github.com/nf-core/genomeassembler/pull/215/changes/f181bdf94e7c97b572568bc41d05b6059a9c2997) 

Since the channel was not a map, `meta.strategy` selection in did not work for those cases (cp: [this commit in #215](https://github.com/nf-core/genomeassembler/pull/215/changes/cba85c3f5efa61326f740caff202743e2693b487).