### PR TITLE
Add `manifest.diagram` to `nextflow.config`

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -431,6 +431,7 @@ manifest {
     nextflowVersion = '!>=25.10.4'
     version         = '2.0.0'
     doi             = '10.5281/zenodo.14986998'
+    diagram         = 'docs/images/genomeassembler_light.svg'
 }
 
 // Nextflow plugins


### PR DESCRIPTION
Adds the new `manifest.diagram` config attribute, pointing at the pipeline overview diagram.

See nf-core/tools#4460 for background: `manifest.diagram` gives a canonical location for the metro map, so that downstream consumers can find it. We'll use it for the nf-core website soon, for example. The new config option won't be released until Nextflow `26.10`, but older versions ignore unknown manifest fields, so it's safe to set in any pipeline today.

> [!NOTE]
> This looks like it's been generated from nf-metro, but there's no source `.mmd` file in the repo. If possible, please add it to `assets/metro_map.mmd` and then it can be easily regenerated with new versions of nf-metro / updated by others when the pipeline changes.